### PR TITLE
Addressed some feedback from Akane

### DIFF
--- a/Features/Levels/Get/Hot/Endpoint.cs
+++ b/Features/Levels/Get/Hot/Endpoint.cs
@@ -24,7 +24,7 @@ internal class Endpoint : PopularityBaseEndpoint<LevelsGetHotResponseDTO>
     /// <inheritdoc />
     public override async Task HandleAsync(GenericGetRequestDTO req, CancellationToken ct)
     {
-        List<LevelPopularityResponseModel> levels = await GetLevelsFromCache(req, "hot", ct);
+        List<LevelPopularityResponseModel> levels = await GetLevelsFromCache(req, "hot", 10, ct);
 
         LevelsGetHotResponseDTO response = new()
         {

--- a/Features/Levels/Get/Hot/Endpoint.cs
+++ b/Features/Levels/Get/Hot/Endpoint.cs
@@ -1,18 +1,17 @@
-﻿using FastEndpoints;
-using Microsoft.Extensions.Caching.Memory;
+﻿using Microsoft.Extensions.Caching.Memory;
+using TNRD.Zeepkist.GTR.Database;
+using TNRD.Zeepkist.GTR.DTOs.RequestDTOs;
 using TNRD.Zeepkist.GTR.DTOs.ResponseDTOs;
 using TNRD.Zeepkist.GTR.DTOs.ResponseModels;
 
 namespace TNRD.Zeepkist.GTR.Backend.Features.Levels.Get.Hot;
 
-internal class Endpoint : EndpointWithoutRequest<LevelsGetHotResponseDTO>
+internal class Endpoint : PopularityBaseEndpoint<LevelsGetHotResponseDTO>
 {
-    private readonly IMemoryCache cache;
-
     /// <inheritdoc />
-    public Endpoint(IMemoryCache cache)
+    public Endpoint(IMemoryCache cache, GTRContext context)
+        : base(cache, context)
     {
-        this.cache = cache;
     }
 
     /// <inheritdoc />
@@ -23,18 +22,14 @@ internal class Endpoint : EndpointWithoutRequest<LevelsGetHotResponseDTO>
     }
 
     /// <inheritdoc />
-    public override async Task HandleAsync(CancellationToken ct)
+    public override async Task HandleAsync(GenericGetRequestDTO req, CancellationToken ct)
     {
+        List<LevelPopularityResponseModel> levels = await GetLevelsFromCache(req, "hot", ct);
+
         LevelsGetHotResponseDTO response = new()
         {
-            Levels = new List<LevelPopularityResponseModel>()
+            Levels = levels
         };
-
-        if (cache.TryGetValue<List<LevelPopularityResponseModel>>("hot",
-                out List<LevelPopularityResponseModel>? cached))
-        {
-            response.Levels = cached!;
-        }
 
         await SendOkAsync(response, ct);
     }

--- a/Features/Levels/Get/Popular/Endpoint.cs
+++ b/Features/Levels/Get/Popular/Endpoint.cs
@@ -24,7 +24,7 @@ internal class Endpoint : PopularityBaseEndpoint<LevelsGetPopularResponseDTO>
     /// <inheritdoc />
     public override async Task HandleAsync(GenericGetRequestDTO req, CancellationToken ct)
     {
-        List<LevelPopularityResponseModel> levels = await GetLevelsFromCache(req, "popular", ct);
+        List<LevelPopularityResponseModel> levels = await GetLevelsFromCache(req, "popular", 50, ct);
 
         LevelsGetPopularResponseDTO response = new()
         {

--- a/Features/Levels/Get/Popular/Endpoint.cs
+++ b/Features/Levels/Get/Popular/Endpoint.cs
@@ -1,18 +1,17 @@
-﻿using FastEndpoints;
-using Microsoft.Extensions.Caching.Memory;
+﻿using Microsoft.Extensions.Caching.Memory;
+using TNRD.Zeepkist.GTR.Database;
+using TNRD.Zeepkist.GTR.DTOs.RequestDTOs;
 using TNRD.Zeepkist.GTR.DTOs.ResponseDTOs;
 using TNRD.Zeepkist.GTR.DTOs.ResponseModels;
 
 namespace TNRD.Zeepkist.GTR.Backend.Features.Levels.Get.Popular;
 
-internal class Endpoint : EndpointWithoutRequest<LevelsGetPopularResponseDTO>
+internal class Endpoint : PopularityBaseEndpoint<LevelsGetPopularResponseDTO>
 {
-    private readonly IMemoryCache cache;
-
     /// <inheritdoc />
-    public Endpoint(IMemoryCache cache)
+    public Endpoint(IMemoryCache cache, GTRContext context)
+        : base(cache, context)
     {
-        this.cache = cache;
     }
 
     /// <inheritdoc />
@@ -23,18 +22,14 @@ internal class Endpoint : EndpointWithoutRequest<LevelsGetPopularResponseDTO>
     }
 
     /// <inheritdoc />
-    public override async Task HandleAsync(CancellationToken ct)
+    public override async Task HandleAsync(GenericGetRequestDTO req, CancellationToken ct)
     {
+        List<LevelPopularityResponseModel> levels = await GetLevelsFromCache(req, "popular", ct);
+
         LevelsGetPopularResponseDTO response = new()
         {
-            Levels = new List<LevelPopularityResponseModel>()
+            Levels = levels
         };
-
-        if (cache.TryGetValue<List<LevelPopularityResponseModel>>("popular",
-                out List<LevelPopularityResponseModel>? cached))
-        {
-            response.Levels = cached!;
-        }
 
         await SendOkAsync(response, ct);
     }

--- a/Features/Levels/Get/PopularityBaseEndpoint.cs
+++ b/Features/Levels/Get/PopularityBaseEndpoint.cs
@@ -1,0 +1,47 @@
+﻿using FastEndpoints;
+using Microsoft.Extensions.Caching.Memory;
+using TNRD.Zeepkist.GTR.Backend.Extensions;
+using TNRD.Zeepkist.GTR.Database;
+using TNRD.Zeepkist.GTR.Database.Models;
+using TNRD.Zeepkist.GTR.DTOs.RequestDTOs;
+using TNRD.Zeepkist.GTR.DTOs.ResponseModels;
+
+namespace TNRD.Zeepkist.GTR.Backend.Features.Levels.Get;
+
+internal class PopularityBaseEndpoint<T> : Endpoint<GenericGetRequestDTO, T>
+{
+    private readonly IMemoryCache cache;
+    private readonly GTRContext context;
+
+    protected PopularityBaseEndpoint(IMemoryCache cache, GTRContext context)
+    {
+        this.cache = cache;
+        this.context = context;
+    }
+
+    protected async Task<List<LevelPopularityResponseModel>> GetLevelsFromCache(
+        GenericGetRequestDTO req,
+        string key,
+        CancellationToken ct
+    )
+    {
+        if (!cache.TryGetValue<List<LevelPopularityResponseModel>>(key, out List<LevelPopularityResponseModel>? cached))
+            return new List<LevelPopularityResponseModel>();
+
+        int limit = req.Limit ?? 10;
+        int offset = req.Offset ?? 0;
+        List<LevelPopularityResponseModel> levels = cached.Skip(offset).Take(limit).ToList();
+
+        foreach (LevelPopularityResponseModel model in levels)
+        {
+            Record? worldRecord = await context.Records.AsNoTracking()
+                .Where(x => x.IsWr && x.Level == model.Level.Id)
+                .Include(x => x.UserNavigation)
+                .FirstOrDefaultAsync(ct);
+
+            model.Level.WorldRecord = worldRecord?.ToResponseModel() ?? null;
+        }
+
+        return levels;
+    }
+}

--- a/Features/Levels/Get/PopularityBaseEndpoint.cs
+++ b/Features/Levels/Get/PopularityBaseEndpoint.cs
@@ -22,13 +22,14 @@ internal class PopularityBaseEndpoint<T> : Endpoint<GenericGetRequestDTO, T>
     protected async Task<List<LevelPopularityResponseModel>> GetLevelsFromCache(
         GenericGetRequestDTO req,
         string key,
+        int defaultLimit,
         CancellationToken ct
     )
     {
         if (!cache.TryGetValue<List<LevelPopularityResponseModel>>(key, out List<LevelPopularityResponseModel>? cached))
             return new List<LevelPopularityResponseModel>();
 
-        int limit = req.Limit ?? 10;
+        int limit = req.Limit ?? defaultLimit;
         int offset = req.Offset ?? 0;
         List<LevelPopularityResponseModel> levels = cached.Skip(offset).Take(limit).ToList();
 

--- a/Jobs/CalculateHotLevelsJob.cs
+++ b/Jobs/CalculateHotLevelsJob.cs
@@ -20,7 +20,7 @@ internal class CalculateHotLevelsJob : PopularityJobBase
     /// <inheritdoc />
     protected override int GetTakeCount()
     {
-        return 10;
+        return 100;
     }
 
     /// <inheritdoc />

--- a/Jobs/CalculatePopularLevelsJob.cs
+++ b/Jobs/CalculatePopularLevelsJob.cs
@@ -20,7 +20,7 @@ internal class CalculatePopularLevelsJob : PopularityJobBase
     /// <inheritdoc />
     protected override int GetTakeCount()
     {
-        return 50;
+        return 100;
     }
 
     /// <inheritdoc />

--- a/Zeepkist.GTR.Backend.csproj
+++ b/Zeepkist.GTR.Backend.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
         <PackageReference Include="SteamWebAPI2" Version="4.4.0" />
         <PackageReference Include="TNRD.Zeepkist.GTR.Database" Version="1.1.0" />
-        <PackageReference Include="TNRD.Zeepkist.GTR.DTOs" Version="3.8.0" />
+        <PackageReference Include="TNRD.Zeepkist.GTR.DTOs" Version="3.9.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Sorting by level points shows invalid order. Items with `null` points where placed on top. Levels no longer have `null` points by default but `0`
- You can now apply your query when searching levels to only the author or only the level as well
- Level popularity endpoints by default have 100 items and can be limited and offset
- Level popularity endpoints will manually query world record holders to have latest information